### PR TITLE
Set up Notion RSS ingestion project

### DIFF
--- a/.github/workflows/rss-to-notion.yml
+++ b/.github/workflows/rss-to-notion.yml
@@ -1,0 +1,38 @@
+name: RSS → Notion
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/30 * * * *"  # every 30 minutes
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Ingest RSS → Notion
+        env:
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+          RSS_FEEDS: ${{ secrets.RSS_FEEDS }}
+          MAX_ITEMS_PER_FEED: ${{ secrets.MAX_ITEMS_PER_FEED }}
+          ALLOW_UPDATES: ${{ secrets.ALLOW_UPDATES }}
+          USER_AGENT: ${{ secrets.USER_AGENT }}
+        run: |
+          python src/rss_to_notion.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# notion-rss
+# Notion RSS Sync
+
+Import items from one or more RSS feeds into a Notion database with idempotent upserts and a ready-to-run GitHub Actions workflow.
+
+## Features
+
+- ✅ Multi-feed ingestion with polite pacing to respect rate limits.
+- ✅ Idempotent upsert keyed by the Notion `URL` property with optional update suppression.
+- ✅ Tag extraction from RSS `<category>` values when the Notion database exposes a `Tags` multi-select field.
+- ✅ Works great on macOS: the repo ships with a simple `python3` workflow that runs locally or in GitHub Actions without extra tooling.
+
+## Notion database setup
+
+Create (or reuse) a Notion database with at least the following properties:
+
+| Property name | Type        | Notes                                 |
+| ------------- | ----------- | ------------------------------------- |
+| Title         | Title       | Feed item title (fallback to link).   |
+| URL           | URL         | Used as the unique identifier.        |
+| Published     | Date        | Automatically parsed if available.    |
+| Source        | Select      | Populated with the feed title/domain. |
+| Summary       | Rich text   | Raw summary text from the feed.       |
+| Author        | Rich text   | Optional author field.                |
+| Tags          | Multi-select| Optional; filled from feed categories.|
+
+> ℹ️ You can extend `build_properties()` in [`src/rss_to_notion.py`](src/rss_to_notion.py) to map additional database properties.
+
+Share the database with your Notion integration: open the database → **Share** → invite the integration you created in [Notion developer settings](https://www.notion.so/my-integrations).
+
+## Configuration
+
+Set the following secrets in **GitHub → Settings → Secrets and variables → Actions** (or export them locally when testing):
+
+| Secret | Required | Description |
+| ------ | -------- | ----------- |
+| `NOTION_API_KEY` | ✅ | Internal integration key copied from Notion. |
+| `NOTION_DATABASE_ID` | ✅ | Short database ID (the characters between the last slash and `?` in the URL). |
+| `RSS_FEEDS` | ✅ | Comma-separated list of RSS/Atom feed URLs. |
+| `MAX_ITEMS_PER_FEED` | ❌ | Limit items processed per feed (default `30`). |
+| `ALLOW_UPDATES` | ❌ | `true` (default) to update existing pages, `false` for create-only mode. |
+| `USER_AGENT` | ❌ | Custom HTTP user agent string for feed requests. |
+
+## Local development on macOS
+
+1. Install Python 3.11 (macOS ships with `python3`, but you can also use [Homebrew](https://brew.sh/) to install a newer version).
+2. Clone the repository and set the required environment variables in your shell:
+
+   ```bash
+   export NOTION_API_KEY=... \
+          NOTION_DATABASE_ID=... \
+          RSS_FEEDS="https://news.ycombinator.com/rss,https://www.xinhuanet.com/english/rss/worldrss.xml"
+   ```
+
+3. Create and activate a virtual environment:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate  # on macOS/Linux shells
+   ```
+
+4. Install dependencies and run the ingester:
+
+   ```bash
+   pip install -r requirements.txt
+   python src/rss_to_notion.py
+   ```
+
+The script prints a summary for each feed (`new`, `updated`, `skipped`) followed by a total count of pages upserted.
+
+## GitHub Actions automation
+
+The repository includes [`.github/workflows/rss-to-notion.yml`](.github/workflows/rss-to-notion.yml) which:
+
+- Runs on demand (`workflow_dispatch`) or every 30 minutes via cron.
+- Uses Python 3.11 on `ubuntu-latest` runners.
+- Installs requirements and invokes `python src/rss_to_notion.py` with the configured secrets.
+
+Once secrets are configured, enable the workflow and watch the Action logs for ingestion summaries.
+
+## Extending the flow
+
+- **Tag strategy** – Apply fixed tags per feed by augmenting `build_properties()` with a lookup dictionary.
+- **HTML handling** – Feed summaries may contain HTML. Integrate `beautifulsoup4` to strip or transform markup before storing it in Notion.
+- **Full-text extraction** – Use readability libraries or paid extraction services to populate a richer property.
+- **Backfill** – Temporarily raise `MAX_ITEMS_PER_FEED` to reprocess older entries.
+- **Create-only mode** – Set `ALLOW_UPDATES=false` to avoid updating existing pages.
+
+Happy automating! 🚀

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+notion-client==2.2.1
+feedparser==6.0.11
+backoff==2.2.1
+python-dateutil==2.9.0.post0

--- a/src/rss_to_notion.py
+++ b/src/rss_to_notion.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import feedparser
+from notion_client import Client
+from dateutil import parser as dateparser
+import backoff
+
+NOTION_KEY = os.getenv("NOTION_API_KEY", "").strip()
+DB_ID = os.getenv("NOTION_DATABASE_ID", "").strip()
+RSS_FEEDS = [u.strip() for u in os.getenv("RSS_FEEDS", "").split(",") if u.strip()]
+MAX_ITEMS = int(os.getenv("MAX_ITEMS_PER_FEED", "30"))
+ALLOW_UPDATES = os.getenv("ALLOW_UPDATES", "true").lower() in {"1", "true", "yes"}
+USER_AGENT = os.getenv("USER_AGENT", "notion-rss-bot/1.0 (+https://github.com/your/repo)")
+
+if not (NOTION_KEY and DB_ID and RSS_FEEDS):
+    raise SystemExit("Missing NOTION_API_KEY, NOTION_DATABASE_ID or RSS_FEEDS envs.")
+
+notion = Client(auth=NOTION_KEY)
+
+
+# ---------- Notion helpers ----------
+
+
+def to_iso(dt_str: Optional[str]) -> Optional[str]:
+    if not dt_str:
+        return None
+    try:
+        return dateparser.parse(dt_str).isoformat()
+    except Exception:
+        return None
+
+
+def build_properties(entry: Dict, source_name: str) -> Dict:
+    title = entry.get("title") or entry.get("link") or "Untitled"
+    url = entry.get("link") or ""
+    published = (
+        to_iso(entry.get("published"))
+        or to_iso(entry.get("updated"))
+        or to_iso(entry.get("created"))
+    )
+    author = entry.get("author") or ""
+    summary = entry.get("summary") or entry.get("subtitle") or ""
+
+    # Tags from RSS categories if present
+    tags: List[Dict[str, str]] = []
+    if "tags" in entry and isinstance(entry["tags"], list):
+        for t in entry["tags"]:
+            name = t.get("term") or t.get("label")
+            if name:
+                tags.append({"name": name[:90]})
+
+    props = {
+        "Title": {"title": [{"text": {"content": title[:200]}}]},
+        "URL": {"url": url},
+        "Published": {"date": {"start": published} if published else None},
+        "Source": {"select": {"name": source_name[:90]}},
+        "Summary": {"rich_text": [{"text": {"content": summary[:1900]}}]} if summary else {"rich_text": []},
+        "Author": {"rich_text": [{"text": {"content": author[:200]}}]} if author else {"rich_text": []},
+    }
+
+    # Only include Tags if property exists; otherwise Notion errors
+    try:
+        # quick property presence probe
+        db = notion.databases.retrieve(DB_ID)
+        if "Tags" in db.get("properties", {}):
+            props["Tags"] = {"multi_select": tags}
+    except Exception:
+        pass
+
+    return props
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, jitter=backoff.full_jitter)
+def query_page_by_url(url: str) -> Optional[str]:
+    """
+    Find an existing page by URL (exact match) to ensure idempotent upsert.
+    """
+    if not url:
+        return None
+    resp = notion.databases.query(
+        **{
+            "database_id": DB_ID,
+            "filter": {
+                "property": "URL",
+                "url": {"equals": url}
+            },
+            "page_size": 1,
+        }
+    )
+    results = resp.get("results", [])
+    return results[0]["id"] if results else None
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, jitter=backoff.full_jitter)
+def create_page(props: Dict):
+    return notion.pages.create(parent={"database_id": DB_ID}, properties=props)
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, jitter=backoff.full_jitter)
+def update_page(page_id: str, props: Dict):
+    return notion.pages.update(page_id=page_id, properties=props)
+
+
+# ---------- RSS ingestion ----------
+
+
+def source_name_from_feed(feed: feedparser.FeedParserDict) -> str:
+    title = (feed.get("feed", {}) or {}).get("title")
+    link = (feed.get("feed", {}) or {}).get("link")
+    return (title or link or "RSS").strip()
+
+
+def harvest_feed(url: str) -> int:
+    parsed = feedparser.parse(url, agent=USER_AGENT)
+    if parsed.bozo and getattr(parsed.bozo_exception, "getMessage", None):
+        print(f"[warn] feed parse issue for {url}: {parsed.bozo_exception}")
+
+    src = source_name_from_feed(parsed)
+    count_new, count_updated, count_skipped = 0, 0, 0
+
+    for entry in (parsed.entries or [])[:MAX_ITEMS]:
+        # normalize essentials
+        entry_link = entry.get("link") or ""
+        if not entry_link:
+            count_skipped += 1
+            continue
+
+        props = build_properties(entry, src)
+        existing_id = query_page_by_url(entry_link)
+
+        if existing_id is None:
+            create_page(props)
+            count_new += 1
+        else:
+            if ALLOW_UPDATES:
+                update_page(existing_id, props)
+                count_updated += 1
+            else:
+                count_skipped += 1
+
+        # polite pacing vs. Notion rate limits
+        time.sleep(0.2)
+
+    print(f"[{src}] new={count_new} updated={count_updated} skipped={count_skipped}")
+    return count_new + count_updated
+
+
+def main():
+    total = 0
+    for url in RSS_FEEDS:
+        try:
+            total += harvest_feed(url)
+        except Exception as e:
+            print(f"[error] {url}: {e}")
+    print(f"[done] pages upserted: {total}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the Python ingester that upserts RSS feed entries into the configured Notion database
- document macOS-friendly setup guidance and configuration requirements in the README
- provide dependencies and an automated GitHub Actions workflow to run the sync on demand or on a schedule

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d41a80910c83218912e01dbae2635d