### PR TITLE
Add full article extraction and markdown storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Import items from one or more RSS feeds into a Notion database with idempotent u
 - ✅ Multi-feed ingestion with polite pacing to respect rate limits.
 - ✅ Idempotent upsert keyed by the Notion `URL` property with optional update suppression.
 - ✅ Tag extraction from RSS `<category>` values when the Notion database exposes a `Tags` multi-select field.
+- ✅ Optional full-article extraction converted to Markdown (via Readability + `html2markdown`) for richer Notion records.
 - ✅ Works great on macOS: the repo ships with a simple `python3` workflow that runs locally or in GitHub Actions without extra tooling.
 
 ## Notion database setup
@@ -20,10 +21,13 @@ Create (or reuse) a Notion database with at least the following properties:
 | Published     | Date        | Automatically parsed if available.    |
 | Source        | Select      | Populated with the feed title/domain. |
 | Summary       | Rich text   | Raw summary text from the feed.       |
+| Content       | Rich text   | Optional; Markdown full article text (defaults to `Content`). |
 | Author        | Rich text   | Optional author field.                |
 | Tags          | Multi-select| Optional; filled from feed categories.|
 
 > ℹ️ You can extend `build_properties()` in [`src/rss_to_notion.py`](src/rss_to_notion.py) to map additional database properties.
+
+Enable the full-text feature by adding a rich-text property (default name `Content`) to your database. The property name can be customised via `ARTICLE_CONTENT_PROPERTY` if you prefer a different label.
 
 Share the database with your Notion integration: open the database → **Share** → invite the integration you created in [Notion developer settings](https://www.notion.so/my-integrations).
 
@@ -39,6 +43,9 @@ Set the following secrets in **GitHub → Settings → Secrets and variables →
 | `MAX_ITEMS_PER_FEED` | ❌ | Limit items processed per feed (default `30`). |
 | `ALLOW_UPDATES` | ❌ | `true` (default) to update existing pages, `false` for create-only mode. |
 | `USER_AGENT` | ❌ | Custom HTTP user agent string for feed requests. |
+| `FETCH_FULL_CONTENT` | ❌ | `true` (default) to fetch and store article bodies using Readability. |
+| `ARTICLE_CONTENT_PROPERTY` | ❌ | Notion rich-text property used to store Markdown full text (default `Content`). |
+| `ARTICLE_FETCH_TIMEOUT` | ❌ | Timeout in seconds for article download requests (default `10`). |
 
 ## Local development on macOS
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ notion-client==2.2.1
 feedparser==6.0.11
 backoff==2.2.1
 python-dateutil==2.9.0.post0
+requests==2.31.0
+readability-lxml==0.8.1
+html2markdown==0.1.7

--- a/src/rss_to_notion.py
+++ b/src/rss_to_notion.py
@@ -3,12 +3,15 @@
 
 import os
 import time
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 import feedparser
 from notion_client import Client
 from dateutil import parser as dateparser
 import backoff
+import requests
+from readability import Document
+from html2markdown import convert as html2markdown_convert
 
 NOTION_KEY = os.getenv("NOTION_API_KEY", "").strip()
 DB_ID = os.getenv("NOTION_DATABASE_ID", "").strip()
@@ -16,11 +19,22 @@ RSS_FEEDS = [u.strip() for u in os.getenv("RSS_FEEDS", "").split(",") if u.strip
 MAX_ITEMS = int(os.getenv("MAX_ITEMS_PER_FEED", "30"))
 ALLOW_UPDATES = os.getenv("ALLOW_UPDATES", "true").lower() in {"1", "true", "yes"}
 USER_AGENT = os.getenv("USER_AGENT", "notion-rss-bot/1.0 (+https://github.com/your/repo)")
+FETCH_FULL_CONTENT = os.getenv("FETCH_FULL_CONTENT", "true").lower() in {"1", "true", "yes"}
+ARTICLE_CONTENT_PROPERTY = os.getenv("ARTICLE_CONTENT_PROPERTY", "Content").strip()
+ARTICLE_FETCH_TIMEOUT = float(os.getenv("ARTICLE_FETCH_TIMEOUT", "10"))
 
 if not (NOTION_KEY and DB_ID and RSS_FEEDS):
     raise SystemExit("Missing NOTION_API_KEY, NOTION_DATABASE_ID or RSS_FEEDS envs.")
 
 notion = Client(auth=NOTION_KEY)
+
+session = requests.Session()
+if USER_AGENT:
+    session.headers.update({"User-Agent": USER_AGENT})
+
+
+_DB_PROPERTIES_CACHE: Optional[Dict[str, Dict]] = None
+_CONTENT_PROPERTY_WARNED = False
 
 
 # ---------- Notion helpers ----------
@@ -35,7 +49,36 @@ def to_iso(dt_str: Optional[str]) -> Optional[str]:
         return None
 
 
-def build_properties(entry: Dict, source_name: str) -> Dict:
+def chunk_text(text: str, chunk_size: int = 1900) -> Iterable[str]:
+    for idx in range(0, len(text), chunk_size):
+        yield text[idx : idx + chunk_size]
+
+
+def to_rich_text(text: str, chunk_size: int = 1900) -> List[Dict[str, Dict[str, str]]]:
+    return [{"text": {"content": chunk}} for chunk in chunk_text(text, chunk_size)]
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, jitter=backoff.full_jitter)
+def fetch_database_properties() -> Dict[str, Dict]:
+    db = notion.databases.retrieve(DB_ID)
+    return db.get("properties", {})
+
+
+def database_has_property(name: str) -> bool:
+    global _DB_PROPERTIES_CACHE
+    if not name:
+        return False
+    if _DB_PROPERTIES_CACHE is None:
+        try:
+            _DB_PROPERTIES_CACHE = fetch_database_properties()
+        except Exception as exc:
+            print(f"[warn] unable to inspect database properties: {exc}")
+            _DB_PROPERTIES_CACHE = {}
+    return name in _DB_PROPERTIES_CACHE
+
+
+def build_properties(entry: Dict, source_name: str, article_markdown: Optional[str]) -> Dict:
+    global _CONTENT_PROPERTY_WARNED
     title = entry.get("title") or entry.get("link") or "Untitled"
     url = entry.get("link") or ""
     published = (
@@ -59,20 +102,86 @@ def build_properties(entry: Dict, source_name: str) -> Dict:
         "URL": {"url": url},
         "Published": {"date": {"start": published} if published else None},
         "Source": {"select": {"name": source_name[:90]}},
-        "Summary": {"rich_text": [{"text": {"content": summary[:1900]}}]} if summary else {"rich_text": []},
+        "Summary": {"rich_text": to_rich_text(summary)} if summary else {"rich_text": []},
         "Author": {"rich_text": [{"text": {"content": author[:200]}}]} if author else {"rich_text": []},
     }
 
     # Only include Tags if property exists; otherwise Notion errors
-    try:
-        # quick property presence probe
-        db = notion.databases.retrieve(DB_ID)
-        if "Tags" in db.get("properties", {}):
-            props["Tags"] = {"multi_select": tags}
-    except Exception:
-        pass
+    if database_has_property("Tags"):
+        props["Tags"] = {"multi_select": tags}
+
+    if article_markdown and ARTICLE_CONTENT_PROPERTY:
+        if database_has_property(ARTICLE_CONTENT_PROPERTY):
+            props[ARTICLE_CONTENT_PROPERTY] = {"rich_text": to_rich_text(article_markdown)}
+        else:
+            if not _CONTENT_PROPERTY_WARNED:
+                print(
+                    f"[warn] Notion database is missing the '{ARTICLE_CONTENT_PROPERTY}' property. "
+                    "Full article content will be skipped."
+                )
+                _CONTENT_PROPERTY_WARNED = True
 
     return props
+
+
+def _normalize_html_value(entry: Dict) -> List[str]:
+    html_parts: List[str] = []
+    content = entry.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                value = part.get("value")
+                if value:
+                    html_parts.append(str(value))
+    summary_detail = entry.get("summary_detail")
+    if isinstance(summary_detail, dict):
+        if summary_detail.get("type", "").lower().startswith("text/html"):
+            value = summary_detail.get("value")
+            if value:
+                html_parts.append(str(value))
+    summary = entry.get("summary")
+    if summary:
+        html_parts.append(str(summary))
+    return html_parts
+
+
+def fetch_article_html(url: str) -> Optional[str]:
+    try:
+        resp = session.get(url, timeout=ARTICLE_FETCH_TIMEOUT)
+        resp.raise_for_status()
+        if not resp.encoding:
+            resp.encoding = resp.apparent_encoding
+        return resp.text
+    except requests.RequestException as exc:
+        print(f"[warn] unable to fetch article content from {url}: {exc}")
+        return None
+
+
+def extract_article_markdown(entry: Dict) -> Optional[str]:
+    url = entry.get("link") or ""
+    if not url:
+        return None
+
+    html = fetch_article_html(url)
+    if html:
+        try:
+            doc = Document(html)
+            article_html = doc.summary()
+            markdown = html2markdown_convert(article_html or "").strip()
+            if markdown:
+                return markdown
+        except Exception as exc:
+            print(f"[warn] readability extraction failed for {url}: {exc}")
+
+    for candidate in _normalize_html_value(entry):
+        try:
+            markdown = html2markdown_convert(candidate).strip()
+        except Exception:
+            continue
+        if markdown:
+            return markdown
+
+    return None
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, jitter=backoff.full_jitter)
@@ -122,6 +231,16 @@ def harvest_feed(url: str) -> int:
 
     src = source_name_from_feed(parsed)
     count_new, count_updated, count_skipped = 0, 0, 0
+    should_fetch_content = FETCH_FULL_CONTENT and bool(ARTICLE_CONTENT_PROPERTY)
+    if should_fetch_content and not database_has_property(ARTICLE_CONTENT_PROPERTY):
+        global _CONTENT_PROPERTY_WARNED
+        if not _CONTENT_PROPERTY_WARNED:
+            print(
+                f"[warn] Notion database is missing the '{ARTICLE_CONTENT_PROPERTY}' property. "
+                "Full article content will be skipped."
+            )
+            _CONTENT_PROPERTY_WARNED = True
+        should_fetch_content = False
 
     for entry in (parsed.entries or [])[:MAX_ITEMS]:
         # normalize essentials
@@ -130,7 +249,8 @@ def harvest_feed(url: str) -> int:
             count_skipped += 1
             continue
 
-        props = build_properties(entry, src)
+        article_markdown = extract_article_markdown(entry) if should_fetch_content else None
+        props = build_properties(entry, src, article_markdown)
         existing_id = query_page_by_url(entry_link)
 
         if existing_id is None:


### PR DESCRIPTION
## Summary
- fetch article bodies with requests/readability and convert them to Markdown via html2markdown when the Content property exists
- cache Notion database metadata and add helpers to safely populate summary, tags, and full-text rich text fields
- document the new configuration flags, Content property requirements, and add required dependencies

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d4205b2a74832181fc9e5343470880