### PR TITLE
Handle readability dependency and add html clean package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil==2.9.0.post0
 requests==2.31.0
 readability-lxml==0.8.1
 html2markdown==0.1.7
+lxml-html-clean==0.1.0


### PR DESCRIPTION
## Summary
- make readability-lxml optional at runtime and provide a clear warning when its dependencies are missing
- fall back to feed content conversion when readability is unavailable so ingestion continues working
- add the lxml-html-clean dependency required by readability on newer lxml versions

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d43079cf748321ad40be36b5d88ebc